### PR TITLE
Log when Plone content cannot be constructed.

### DIFF
--- a/src/collective/transmogrifier/sections/constructor.py
+++ b/src/collective/transmogrifier/sections/constructor.py
@@ -29,13 +29,15 @@ class ConstructorSection(object):
             typekey = self.typekey(*keys)[0]
             pathkey = self.pathkey(*keys)[0]
             
-            if not (typekey and pathkey):             # not enough info
+            if not (typekey and pathkey):
+                logger.warn('Not enough info for item: %s' % item)
                 yield item; continue
-                        
+            
             type_, path = item[typekey], item[pathkey]
             
             fti = self.ttool.getTypeInfo(type_)
-            if fti is None:                           # not an existing type
+            if fti is None:
+                logger.warn('Not an existing type: %s' % type_)
                 yield item; continue
             
             path = path.encode('ASCII')


### PR DESCRIPTION
A the moment there is no feedback when Plone content cannot be constructed. Sometimes it would be nice to have immediate feedback.

This pull requests adds some warnings to the constructor pipeline section.

Maybe raising an exception when required is True would be a good choice as well, but i'm not 100% sure.