### PR TITLE
Add info during processing, easing e.g. tarball download support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /src/plone*
 /src/collective*
 *.mo
+*~
 docs/Makefile
 docs/make.bat
 docs/doctrees

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -18,7 +18,13 @@ The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
 """
 
-import os, shutil, sys, tempfile, urllib, urllib2, subprocess
+import os
+import shutil
+import sys
+import tempfile
+import urllib
+import urllib2
+import subprocess
 from optparse import OptionParser
 
 if sys.platform == 'win32':
@@ -212,6 +218,7 @@ if version is None and not options.accept_buildout_test_releases:
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
+
     def _final_version(parsed_version):
         for part in parsed_version:
             if (part[:1] == '*') and (part not in _final_parts):
@@ -240,7 +247,7 @@ if version is None and not options.accept_buildout_test_releases:
             version = best[-1].version
 
 if version:
-    requirement += '=='+version
+    requirement += '==' + version
 else:
     requirement += '<2dev'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ long_description = ('\n'.join((
     read('docs', 'HISTORY.txt'),
 )))
 
-
 setup(
     name='collective.transmogrifier',
     version=version,

--- a/src/collective/transmogrifier/genericsetup.py
+++ b/src/collective/transmogrifier/genericsetup.py
@@ -4,6 +4,7 @@ from interfaces import ITransmogrifier
 
 IMPORT_CONTEXT = 'collective.transmogrifier.genericsetup.import_context'
 
+
 def importTransmogrifier(context):
     """Run named transmogrifier pipelines read from transmogrifier.txt
 

--- a/src/collective/transmogrifier/interfaces.py
+++ b/src/collective/transmogrifier/interfaces.py
@@ -1,10 +1,11 @@
 import zope.interface
 
+
 class ITransmogrifier(zope.interface.Interface):
     """The transmogrifier transforms objects through a pipeline"""
-    
+
     context = zope.interface.Attribute("The targeted IFolderish context")
-    
+
     def __call__(self, configuration_id, **overrides):
         """Load and execute the named pipeline configuration
         
@@ -13,20 +14,20 @@ class ITransmogrifier(zope.interface.Interface):
         accepted.
         
         """
-        
+
     def __getitem__(section):
         """Retrieve a section from the pipeline configuration"""
-        
+
     def keys():
         """List all sections in the pipeline configuration"""
-        
+
     def __iter__():
         """Iterate over all the section names in the pipeline configuration"""
 
 
 class ISectionBlueprint(zope.interface.Interface):
     """Blueprints create pipe sections"""
-    
+
     def __call__(transmogrifier, name, options, previous):
         """Create a named pipe section for a transmogrifier
         
@@ -35,9 +36,10 @@ class ISectionBlueprint(zope.interface.Interface):
         
         """
 
+
 class ISection(zope.interface.Interface):
     """A section in a transmogrifier pipe"""
-    
+
     def __iter__():
         """Pipe sections are iterables.
         

--- a/src/collective/transmogrifier/meta.py
+++ b/src/collective/transmogrifier/meta.py
@@ -35,8 +35,9 @@ class IRegisterConfigDirective(Interface):
         description=u"The pipeline configuration file to register.",
         required=True)
 
-
 _configuration_regs = []
+
+
 def registerConfig(_context, configuration, name=u'default', title=None,
                    description=None):
     """Add a new configuration to the registry"""

--- a/src/collective/transmogrifier/sections/breakpoint.py
+++ b/src/collective/transmogrifier/sections/breakpoint.py
@@ -9,7 +9,6 @@ from pdb import Pdb
 
 # Breaks on a condition.
 
-
 class BreakpointSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
@@ -20,7 +19,7 @@ class BreakpointSection(object):
         condition = options['condition']
         self.condition = Condition(condition, transmogrifier, name, options)
         self.previous = previous
-        
+
     def __iter__(self):
         for item in self.previous:
             if self.condition(item):

--- a/src/collective/transmogrifier/sections/codec.py
+++ b/src/collective/transmogrifier/sections/codec.py
@@ -4,58 +4,60 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.utils import Matcher, Condition
 
+
 def _get_default_encoding(site):
     from Products.CMFPlone.utils import getSiteEncoding
     return getSiteEncoding(site)
 
+
 class CodecSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     from_ = None
     from_error_handler = 'strict'
     to = None
     to_error_handler = 'strict'
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
-        
+
         if options.get('from'):
             from_ = options['from'].strip().lower()
             if from_ != 'unicode':
                 if from_ == 'default':
                     from_ = _get_default_encoding(transmogrifier.context)
-                
+
                 # Test if the decoder is available
                 codecs.getdecoder(from_)
-                
+
                 self.from_ = from_
-        
+
         self.from_error_handler = options.get(
             'from-error-handler', self.from_error_handler).strip().lower()
         # Test if the error handler is available
         codecs.lookup_error(self.from_error_handler)
-        
+
         if options.get('to'):
             to = options['to'].strip().lower()
             if to != 'unicode':
                 if to == 'default':
                     to = _get_default_encoding(transmogrifier.context)
-                
+
                 # Test if the encoder is available
                 codecs.getencoder(to)
-                
+
                 self.to = to
-        
+
         self.to_error_handler = options.get(
             'to-error-handler', self.to_error_handler).strip().lower()
         # Test if the error handler is available
         codecs.lookup_error(self.to_error_handler)
-        
+
         self.matcher = Matcher(*options['keys'].splitlines())
         self.condition = Condition(options.get('condition', 'python:True'),
                                    transmogrifier, name, options)
-    
+
     def __iter__(self):
         from_ = self.from_
         if from_ is None:
@@ -65,9 +67,10 @@ class CodecSection(object):
                 return value
         else:
             from_error_handler = self.from_error_handler
+
             def decode(value):
                 return value.decode(from_, from_error_handler)
-        
+
         to = self.to
         if to is None:
             def encode(value):
@@ -76,9 +79,10 @@ class CodecSection(object):
                 return value
         else:
             to_error_handler = self.to_error_handler
+
             def encode(value):
                 return value.encode(to, to_error_handler)
-        
+
         for item in self.previous:
             for key in item:
                 match = self.matcher(key)[1]

--- a/src/collective/transmogrifier/sections/condition.py
+++ b/src/collective/transmogrifier/sections/condition.py
@@ -3,15 +3,16 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.utils import Condition
 
+
 class ConditionSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         condition = options['condition']
         self.condition = Condition(condition, transmogrifier, name, options)
         self.previous = previous
-    
+
     def __iter__(self):
         for item in self.previous:
             if self.condition(item):

--- a/src/collective/transmogrifier/sections/constructor.py
+++ b/src/collective/transmogrifier/sections/constructor.py
@@ -12,35 +12,38 @@ from Products.CMFCore.utils import getToolByName
 import logging
 logger = logging.getLogger('collective.transmogrifier.constructor')
 
+
 class ConstructorSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.context = transmogrifier.context
         self.ttool = getToolByName(self.context, 'portal_types')
-        
-        self.typekey = defaultMatcher(options, 'type-key', name, 'type', 
+
+        self.typekey = defaultMatcher(options, 'type-key', name, 'type',
                                       ('portal_type', 'Type'))
         self.pathkey = defaultMatcher(options, 'path-key', name, 'path')
         self.required = bool(options.get('required'))
-    
+
     def __iter__(self):
         for item in self.previous:
             keys = item.keys()
             typekey = self.typekey(*keys)[0]
             pathkey = self.pathkey(*keys)[0]
-            
+
             if not (typekey and pathkey):             # not enough info
-                yield item; continue
-                        
+                yield item
+                continue
+
             type_, path = item[typekey], item[pathkey]
-            
+
             fti = self.ttool.getTypeInfo(type_)
             if fti is None:                           # not an existing type
-                yield item; continue
-            
+                yield item
+                continue
+
             path = path.encode('ASCII')
             container, id = posixpath.split(path.strip('/'))
             context = traverse(self.context, container, None)
@@ -53,16 +56,17 @@ class ConstructorSection(object):
                 yield item
                 continue
 
-            if getattr(aq_base(context), id, None) is not None: # item exists
-                yield item; continue
-            
+            if getattr(aq_base(context), id, None) is not None:  # item exists
+                yield item
+                continue
+
             obj = fti._constructInstance(context, id)
-            
+
             # For CMF <= 2.1 (aka Plone 3)
             if hasattr(fti, '_finishConstruction'):
                 obj = fti._finishConstruction(obj)
-            
+
             if obj.getId() != id:
                 item[pathkey] = posixpath.join(container, obj.getId())
-            
+
             yield item

--- a/src/collective/transmogrifier/sections/folders.py
+++ b/src/collective/transmogrifier/sections/folders.py
@@ -9,52 +9,53 @@ from collective.transmogrifier.utils import traverse
 class FoldersSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.context = transmogrifier.context
-        
+
         self.pathKey = defaultMatcher(options, 'path-key', name, 'path')
-        
+
         self.newPathKey = options.get('new-path-key', None)
         self.newTypeKey = options.get('new-type-key', '_type')
-        
+
         self.folderType = options.get('folder-type', 'Folder')
-        self.cache      = options.get('cache', 'true').lower() == 'true'
-        
-        self.seen       = set()
-    
+        self.cache = options.get('cache', 'true').lower() == 'true'
+
+        self.seen = set()
+
     def __iter__(self):
-        
+
         for item in self.previous:
-            
+
             keys = item.keys()
             pathKey = self.pathKey(*keys)[0]
-            
-            if not pathKey: # not enough info
-                yield item; continue
-            
+
+            if not pathKey:  # not enough info
+                yield item
+                continue
+
             newPathKey = self.newPathKey or pathKey
             newTypeKey = self.newTypeKey
-            
+
             path = item[pathKey]
             elems = path.strip('/').rsplit('/', 1)
             container, id = (len(elems) == 1 and ('', elems[0]) or elems)
-            
+
             # This may be a new container
             if container not in self.seen:
-                
+
                 containerPathItems = list(pathsplit(container))
                 if containerPathItems:
-                    
+
                     checkedElements = []
-                
+
                     # Check each possible parent folder
                     obj = self.context
                     for element in containerPathItems:
                         checkedElements.append(element)
                         currentPath = '/'.join(checkedElements)
-                    
+
                         if currentPath and currentPath not in self.seen:
 
                             if element and traverse(obj, element) is None:
@@ -69,5 +70,5 @@ class FoldersSection(object):
 
             if self.cache:
                 self.seen.add("%s/%s" % (container, id,))
-            
+
             yield item

--- a/src/collective/transmogrifier/sections/inserter.py
+++ b/src/collective/transmogrifier/sections/inserter.py
@@ -3,10 +3,11 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.utils import Expression, Condition
 
+
 class InserterSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.key = Expression(options['key'], transmogrifier, name, options)
         self.value = Expression(options['value'], transmogrifier, name,
@@ -14,7 +15,7 @@ class InserterSection(object):
         self.condition = Condition(options.get('condition', 'python:True'),
                                    transmogrifier, name, options)
         self.previous = previous
-    
+
     def __iter__(self):
         for item in self.previous:
             key = self.key(item)

--- a/src/collective/transmogrifier/sections/manipulator.py
+++ b/src/collective/transmogrifier/sections/manipulator.py
@@ -4,10 +4,11 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.utils import Matcher, Expression, Condition
 
+
 class ManipulatorSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         keys = options.get('keys') or ''
         self.keys = Matcher(*keys.splitlines())
@@ -18,7 +19,7 @@ class ManipulatorSection(object):
         self.condition = Condition(options.get('condition', 'python:True'),
                                    transmogrifier, name, options)
         self.previous = previous
-    
+
     def __iter__(self):
         for item in self.previous:
             if self.condition(item):

--- a/src/collective/transmogrifier/sections/pathresolver.py
+++ b/src/collective/transmogrifier/sections/pathresolver.py
@@ -8,6 +8,7 @@ from collective.transmogrifier.utils import traverse
 def boolean(val):
     return val.lower() in ('yes', 'true', 'on', '1')
 
+
 def assequence(val):
     """If a string, make it a sequence
     
@@ -18,17 +19,18 @@ def assequence(val):
         return True, (val,)
     return False, val
 
+
 class PathResolverSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.keys = Matcher(*options['keys'].splitlines())
         self.defer = boolean(options.get('defer-until-present', 'no'))
         self.previous = previous
         self._deferred = []
         self.context = transmogrifier.context
-    
+
     def process_item(self, item, defer=None):
         """Replace paths with objects
         
@@ -43,7 +45,7 @@ class PathResolverSection(object):
             defer = self.defer
         context = self.context
         resolved = {}
-        
+
         for key in item.keys():
             match = self.keys(key)[1]
             if match:
@@ -58,10 +60,10 @@ class PathResolverSection(object):
                     # Strip unresolved items
                     result = filter(lambda x: x is not None, result)
                 resolved[key] = result
-        
+
         item.update(resolved)
         return True
-    
+
     def process_deferred(self):
         """Process deferred items
         
@@ -75,7 +77,7 @@ class PathResolverSection(object):
                 yield item
             else:
                 self._deferred.append(item)
-    
+
     def __iter__(self):
         for item in self.previous:
             if self.process_item(item):
@@ -84,7 +86,7 @@ class PathResolverSection(object):
                     yield item
             else:
                 self._deferred.append(item)
-        
+
         # anything in the queue still needs to be processed
         # without deferring (skipping non-existing items)
         for item in self._deferred:

--- a/src/collective/transmogrifier/sections/savepoint.py
+++ b/src/collective/transmogrifier/sections/savepoint.py
@@ -3,14 +3,15 @@ from zope.interface import classProvides, implements
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.interfaces import ISection
 
+
 class SavepointSection(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
-    
+
     def __init__(self, transmogrifier, name, options, previous):
         self.every = int(options.get('every', 1000))
         self.previous = previous
-    
+
     def __iter__(self):
         count = 0
         for item in self.previous:

--- a/src/collective/transmogrifier/sections/tests.py
+++ b/src/collective/transmogrifier/sections/tests.py
@@ -87,6 +87,7 @@ class SplitterConditionSectionTests(unittest.TestCase):
             self.assertEqual(original, yielded)
             self.assertFalse(original is yielded)
 
+
 class SplitterSectionTests(unittest.TestCase):
     def _makeOne(self, transmogrifier, options, previous):
         from splitter import SplitterSection
@@ -102,8 +103,10 @@ class SplitterSectionTests(unittest.TestCase):
     def testInsertExtra(self):
         class Inserter(object):
             implements(ISection)
+
             def __init__(self, transmogrifier, name, options, previous):
                 self.previous = previous
+
             def __iter__(self):
                 count = 0
                 for item in self.previous:
@@ -134,8 +137,10 @@ class SplitterSectionTests(unittest.TestCase):
     def testSkipItems(self):
         class Skip(object):
             implements(ISection)
+
             def __init__(self, transmogrifier, name, options, previous):
                 self.previous = previous
+
             def __iter__(self):
                 count = 0
                 for item in self.previous:
@@ -182,7 +187,6 @@ class SampleSource(object):
                  status=u'\u00A9'),
         )
 
-
     def __iter__(self):
         for item in self.previous:
             yield item
@@ -193,6 +197,7 @@ class SampleSource(object):
                 item['title'] = item['title'].encode(self.encoding)
                 item['status'] = item['status'].encode(self.encoding)
             yield item
+
 
 class RangeSource(object):
     classProvides(ISectionBlueprint)
@@ -232,38 +237,41 @@ def sectionsSetUp(test):
 
 class MockObjectManager(object):
 
-        _last_path = ['']
+    _last_path = ['']
 
-        def __init__(self, id_='', container=None):
-            self.id = id_
-            if container is None:
-                self._path = ''
-            else:
-                self._path = posixpath.join(container._path, id_)
-            self._last_path[:] = [self._path]
+    def __init__(self, id_='', container=None):
+        self.id = id_
+        if container is None:
+            self._path = ''
+        else:
+            self._path = posixpath.join(container._path, id_)
+        self._last_path[:] = [self._path]
 
-        def _getOb(self, id_, default=_marker):
-            if not self.hasObject(id_):
-                if default is _marker:
-                    raise AttributeError(id_)
-                else:
-                    return default
+    def _getOb(self, id_, default=_marker):
+        if not self.hasObject(id_):
+            if default is _marker:
+                raise AttributeError(id_)
             else:
-                return self.__class__(id_, container=self)
+                return default
+        else:
+            return self.__class__(id_, container=self)
 
 
 def constructorSetUp(test):
     sectionsSetUp(test)
 
     class MockPortal(MockObjectManager):
-        existing = True # Existing object
+        existing = True  # Existing object
 
         @property
-        def portal_types(self): return self
+        def portal_types(self):
+            return self
+
         def getTypeInfo(self, type_name):
             self._last_path[:] = ['']
             self._last_type = type_name
-            if type_name in ('FooType', 'BarType'): return self
+            if type_name in ('FooType', 'BarType'):
+                return self
 
         def hasObject(self, id_):
             if isinstance(id_, unicode):
@@ -314,6 +322,7 @@ def constructorSetUp(test):
     provideUtility(ContentSource,
         name=u'collective.transmogrifier.sections.tests.contentsource')
 
+
 def foldersSetUp(test):
     sectionsSetUp(test)
 
@@ -358,6 +367,7 @@ def foldersSetUp(test):
     provideUtility(FoldersSource,
         name=u'collective.transmogrifier.sections.tests.folderssource')
 
+
 def pdbSetUp(test):
     sectionsSetUp(test)
 
@@ -366,12 +376,14 @@ def pdbSetUp(test):
 
     class Input:
         """A helper to push data onto stdin"""
+
         def __init__(self, src):
             self.lines = src.split('\n')
+
         def readline(self):
             line = self.lines.pop(0)
             print line
-            return line+'\n'
+            return line + '\n'
 
     def make_stdin(data):
         oldstdin = sys.stdin

--- a/src/collective/transmogrifier/tests/__init__.py
+++ b/src/collective/transmogrifier/tests/__init__.py
@@ -11,6 +11,7 @@ from collective.transmogrifier.interfaces import ISection
 
 BASEDIR = None
 
+
 def registerConfig(name, configuration):
     filename = os.path.join(BASEDIR, '%s.cfg' % name)
     open(filename, 'w').write(configuration)
@@ -20,10 +21,11 @@ def registerConfig(name, configuration):
         u"'collective.transmogrifier.tests'" % name,
         u'', filename)
 
+
 def setUp(test):
     global BASEDIR
     BASEDIR = tempfile.mkdtemp('transmogrifierTestConfigs')
-    
+
     class PloneSite(object):
         def Title(self):
             return u'Plone Test Site'
@@ -40,6 +42,7 @@ def setUp(test):
         ISection=ISection,
         plone=PloneSite(),
         ))
+
 
 def tearDown(test):
     from collective.transmogrifier import transmogrifier

--- a/src/collective/transmogrifier/tests/test_transmogrifier.py
+++ b/src/collective/transmogrifier/tests/test_transmogrifier.py
@@ -126,6 +126,7 @@ class OptionSubstitutionTests(unittest.TestCase):
         self.assertRaises(KeyError, operator.itemgetter('dontexist'),
                           opts['empty'])
 
+
 class InclusionManipulationTests(cleanup.CleanUp, unittest.TestCase):
     def setUp(self):
         super(InclusionManipulationTests, self).setUp()
@@ -186,6 +187,7 @@ bar +=
         self.assertEquals(opts['bar']['foo'], 'spam')
         self.assertEquals(opts['bar']['baz'], '')
 
+
 class ConstructPipelineTests(cleanup.CleanUp, unittest.TestCase):
     def _doConstruct(self, transmogrifier, sections, pipeline=None):
         from collective.transmogrifier.utils import constructPipeline
@@ -199,6 +201,7 @@ class ConstructPipelineTests(cleanup.CleanUp, unittest.TestCase):
         class NotAnISection(object):
             def __init__(self, transmogrifier, name, options, previous):
                 self.previous = previous
+
             def __iter__(self):
                 for item in self.previous:
                     yield item
@@ -211,6 +214,7 @@ class ConstructPipelineTests(cleanup.CleanUp, unittest.TestCase):
         classImplements(NotAnISection, ISection)
         # No longer raises
         self._doConstruct(config, ['noisection'])
+
 
 class DefaultKeysTest(unittest.TestCase):
     def _defaultKeys(self, *args):
@@ -228,6 +232,7 @@ class DefaultKeysTest(unittest.TestCase):
             self._defaultKeys('foo.bar.baz', 'spam'),
             ('_foo.bar.baz_spam', '_foo.bar.baz', '_spam'))
 
+
 class PackageReferenceResolverTest(unittest.TestCase):
     def setUp(self):
         self._package_path = os.path.dirname(__file__)[:-len('/tests')]
@@ -243,6 +248,7 @@ class PackageReferenceResolverTest(unittest.TestCase):
     def testNonexistingPackage(self):
         self.assertRaises(ImportError, self._resolvePackageReference,
                           'collective.transmogrifier.nonexistent:test')
+
 
 class MockImportContext(object):
     implements(ITransmogrifier)
@@ -262,15 +268,18 @@ class MockImportContext(object):
         return self
 
     log = ()
+
     def info(self, msg):
         self.log += (msg,)
 
     run = ()
+
     def __call__(self, config):
         from zope.annotation.interfaces import IAnnotations
         from collective.transmogrifier.genericsetup import IMPORT_CONTEXT
         assert IAnnotations(self)[IMPORT_CONTEXT] is self
         self.run += (config,)
+
 
 class GenericSetupImporterTest(unittest.TestCase):
     def setUp(self):

--- a/src/collective/transmogrifier/transmogrifier.py
+++ b/src/collective/transmogrifier/transmogrifier.py
@@ -55,6 +55,7 @@ class Transmogrifier(UserDict.DictMixin):
         self.configuration_id = configuration_id
         self._raw = _load_config(configuration_id, **overrides)
         self._data = {}
+        self.reset_info()
 
         options = self._raw['transmogrifier']
         sections = options['pipeline'].splitlines()
@@ -89,6 +90,43 @@ class Transmogrifier(UserDict.DictMixin):
 
     def __iter__(self):
         return iter(self._raw)
+
+    def add_info(self, category, section, info):
+        """
+        Store a chunk of information with the transmogrifier object;
+        needed e.g. to access an export_context after the __call__.
+        The information is stored in an _collected_info attribute.
+
+        category -- e.g. 'export_context'
+        section --  the name of the section, e.g. 'writer'
+        info --     the actual information
+        """
+        self._collected_info.append({
+                  'category': category,
+                  'section':  section,
+                  'info':     info,
+                  })
+
+    def get_info(self, category=None, section=None, short=False):
+        """
+        Generate stored information
+        """
+        for dic in self._collected_info:
+            if category is not None and dic['category'] != category:
+                continue
+            if section is not None and dic['section'] != section:
+                continue
+            if short:
+                yield dic['info']
+            else:
+                yield dic
+
+    def reset_info(self):
+        a = getattr(self, '_collected_info', None)
+        if a is None:
+            self._collected_info = []
+        else:
+            del a[:]
 
 
 class Options(UserDict.DictMixin):

--- a/src/collective/transmogrifier/transmogrifier.py
+++ b/src/collective/transmogrifier/transmogrifier.py
@@ -10,28 +10,29 @@ from Products.CMFCore.interfaces import IFolderish
 from interfaces import ITransmogrifier
 from utils import resolvePackageReference, constructPipeline
 
+
 class ConfigurationRegistry(object):
     def __init__(self):
         self.clear()
-    
+
     def clear(self):
         self._config_info = {}
         self._config_ids = []
-    
+
     def registerConfiguration(self, name, title, description, configuration):
         if name in self._config_info:
             raise KeyError('Duplicate pipeline configuration: %s' % name)
-        
+
         self._config_ids.append(name)
         self._config_info[name] = dict(
             id=name,
-            title=title, 
-            description=description, 
+            title=title,
+            description=description,
             configuration=configuration)
-            
+
     def getConfiguration(self, id):
         return self._config_info[id].copy()
-        
+
     def listConfigurationIds(self):
         return tuple(self._config_ids)
 
@@ -46,32 +47,32 @@ del addCleanUp
 class Transmogrifier(UserDict.DictMixin):
     implements(ITransmogrifier)
     adapts(IFolderish)
-    
+
     def __init__(self, context):
         self.context = context
-        
+
     def __call__(self, configuration_id, **overrides):
         self.configuration_id = configuration_id
         self._raw = _load_config(configuration_id, **overrides)
         self._data = {}
-            
+
         options = self._raw['transmogrifier']
         sections = options['pipeline'].splitlines()
-        pipeline = constructPipeline(self, sections)       
-        
+        pipeline = constructPipeline(self, sections)
+
         # Pipeline execution
         for item in pipeline:
-            pass # discard once processed
-        
+            pass  # discard once processed
+
     def __getitem__(self, section):
         try:
             return self._data[section]
         except KeyError:
             pass
-        
+
         # May raise key error
         data = self._raw[section]
-        
+
         options = Options(self, section, data)
         self._data[section] = options
         options._substitute()
@@ -89,6 +90,7 @@ class Transmogrifier(UserDict.DictMixin):
     def __iter__(self):
         return iter(self._raw)
 
+
 class Options(UserDict.DictMixin):
     def __init__(self, transmogrifier, section, data):
         self.transmogrifier = transmogrifier
@@ -101,19 +103,19 @@ class Options(UserDict.DictMixin):
         for key, value in self._raw.items():
             if '${' in value:
                 self._cooked[key] = self._sub(value, [(self.section, key)])
-        
+
     def get(self, option, default=None, seen=None):
         try:
             return self._data[option]
         except KeyError:
             pass
-        
+
         value = self._cooked.get(option)
         if value is None:
             value = self._raw.get(option)
             if value is None:
                 return default
-        
+
         if '${' in value:
             key = self.section, option
             if seen is None:
@@ -132,17 +134,18 @@ class Options(UserDict.DictMixin):
     _template_split = re.compile('([$]{[^}]*})').split
     _valid = re.compile('\${[-a-zA-Z0-9 ._]+:[-a-zA-Z0-9 ._]+}$').match
     _tales = re.compile('^\s*string:', re.MULTILINE).match
+
     def _sub(self, template, seen):
         parts = self._template_split(template)
         subs = []
         for ref in parts[1::2]:
             if not self._valid(ref):
-                 # A value with a string: TALES expression?
+                # A value with a string: TALES expression?
                 if self._tales(template):
                     subs.append(ref)
                     continue
                 raise ValueError('Not a valid substitution %s.' % ref)
-            
+
             names = tuple(ref[2:-1].split(':'))
             value = self.transmogrifier[names[0]].get(names[1], None, seen)
             if value is None:
@@ -151,7 +154,7 @@ class Options(UserDict.DictMixin):
         subs.append('')
 
         return ''.join([''.join(v) for v in zip(parts[::2], subs)])
-        
+
     def __getitem__(self, key):
         try:
             return self._data[key]
@@ -190,6 +193,7 @@ class Options(UserDict.DictMixin):
         result.update(self._data)
         return result
 
+
 def _update_section(section, included):
     """Update section dictionary with included options
     
@@ -202,7 +206,7 @@ def _update_section(section, included):
     keys = set(section.keys())
     add = set([k for k in keys if k.endswith('+')])
     remove = set([k for k in keys if k.endswith('-')])
-    
+
     for key in remove:
         option = key.strip(' -')
         if option in keys:
@@ -211,7 +215,7 @@ def _update_section(section, included):
             v for v in included.get(option, '').splitlines()
             if v and v not in section[key].splitlines()])
         del section[key]
-    
+
     for key in add:
         option = key.strip(' +')
         if option in keys:
@@ -221,9 +225,10 @@ def _update_section(section, included):
                        section[key].splitlines()
             if v])
         del section[key]
-    
+
     included.update(section)
     return included
+
 
 def _load_config(configuration_id, seen=None, **overrides):
     if seen is None:
@@ -233,23 +238,23 @@ def _load_config(configuration_id, seen=None, **overrides):
             'Recursive configuration extends: %s (%r)' % (
                 configuration_id, seen))
     seen.append(configuration_id)
-    
+
     if ':' in configuration_id:
         configuration_file = resolvePackageReference(configuration_id)
     else:
         config_info = configuration_registry.getConfiguration(configuration_id)
         configuration_file = config_info['configuration']
     parser = ConfigParser.RawConfigParser()
-    parser.optionxform = str # case sensitive
+    parser.optionxform = str  # case sensitive
     parser.readfp(open(configuration_file))
-    
+
     includes = None
     result = {}
     for section in parser.sections():
         result[section] = dict(parser.items(section))
         if section == 'transmogrifier':
             includes = result[section].pop('include', includes)
-    
+
     if includes:
         for configuration_id in includes.split()[::-1]:
             include = _load_config(configuration_id, seen)
@@ -257,10 +262,10 @@ def _load_config(configuration_id, seen=None, **overrides):
             for section in sections:
                 result[section] = _update_section(
                     result.get(section, {}), include.get(section, {}))
-    
+
     seen.pop()
-    
+
     for section, options in overrides.iteritems():
         result.setdefault(section, {}).update(options)
-    
+
     return result

--- a/src/collective/transmogrifier/utils.py
+++ b/src/collective/transmogrifier/utils.py
@@ -15,6 +15,7 @@ except ImportError:
 from interfaces import ISection
 from interfaces import ISectionBlueprint
 
+
 def openFileReference(transmogrifier, ref):
     """
     Get an open file handle in one of the following forms:
@@ -31,7 +32,7 @@ def openFileReference(transmogrifier, ref):
             from collective.transmogrifier.genericsetup import IMPORT_CONTEXT
             from zope.annotation.interfaces import IAnnotations
             context = IAnnotations(transmogrifier).get(IMPORT_CONTEXT, None)
-            (subdir, filename) = os.path.split(ref.replace('importcontext:',''))
+            (subdir, filename) = os.path.split(ref.replace('importcontext:', ''))
             if subdir == '':
                 # Subdir of '' results import contexts looking for a ''
                 # directory I think
@@ -50,17 +51,19 @@ def openFileReference(transmogrifier, ref):
         return open(filename, 'r')
     return None
 
+
 def resolvePackageReferenceOrFile(reference):
     """A wrapper around def ``resolvePackageReference`` which also work if
     reference is a "plain" filename.
     """
-    
+
     if ':' not in reference:
         return reference
     try:
         return resolvePackageReference(reference)
     except ImportError:
         return reference
+
 
 def resolvePackageReference(reference):
     """Given a package:filename reference, return the filesystem path
@@ -105,8 +108,8 @@ def constructPipeline(transmogrifier, sections, pipeline=None):
     
     """
     if pipeline is None:
-        pipeline = iter(()) # empty starter section
-    
+        pipeline = iter(())  # empty starter section
+
     for section_id in sections:
         section_id = section_id.strip()
         if not section_id:
@@ -114,14 +117,15 @@ def constructPipeline(transmogrifier, sections, pipeline=None):
         section_options = transmogrifier[section_id]
         blueprint_id = section_options['blueprint'].decode('ascii')
         blueprint = getUtility(ISectionBlueprint, blueprint_id)
-        pipeline = blueprint(transmogrifier, section_id, section_options, 
+        pipeline = blueprint(transmogrifier, section_id, section_options,
                              pipeline)
         if not ISection.providedBy(pipeline):
             raise ValueError('Blueprint %s for section %s did not return '
                              'an ISection' % (blueprint_id, section_id))
-        pipeline = iter(pipeline) # ensure you can call .next()
-    
+        pipeline = iter(pipeline)  # ensure you can call .next()
+
     return pipeline
+
 
 def defaultKeys(blueprint, section, key=None):
     """Create a set of item keys based on blueprint id, section name and key
@@ -137,13 +141,14 @@ def defaultKeys(blueprint, section, key=None):
     if key is not None:
         parts.append(key)
     keys = (
-        '_'.join(parts), # _blueprint_section_key or _blueprint_section
-        '_'.join(parts[:2] + parts[3:]), # _blueprint_key or _blueprint
-        '_'.join(parts[:1] + parts[2:]), # _section_key or _section
+        '_'.join(parts),                  # _blueprint_section_key or _blueprint_section
+        '_'.join(parts[:2] + parts[3:]),  # _blueprint_key or _blueprint
+        '_'.join(parts[:1] + parts[2:]),  # _section_key or _section
     )
     if key is not None:
-        keys += ('_'.join(parts[:1] + parts[3:]),) # _key
+        keys += ('_'.join(parts[:1] + parts[3:]),)  # _key
     return keys
+
 
 def defaultMatcher(options, optionname, section, key=None, extra=()):
     """Create a Matcher from an option, with a defaultKeys fallback
@@ -164,6 +169,7 @@ def defaultMatcher(options, optionname, section, key=None, extra=()):
             keys += (key,)
     return Matcher(*keys)
 
+
 class Matcher(object):
     """Given a set of string expressions, return the first match.
     
@@ -180,6 +186,7 @@ class Matcher(object):
     returned.
     
     """
+
     def __init__(self, *expressions):
         self.expressions = []
         for expr in expressions:
@@ -190,9 +197,9 @@ class Matcher(object):
                 expr = expr.split(':', 1)[1]
                 expr = re.compile(expr).match
             else:
-                expr = lambda x, y=expr: x == y
+                expr = lambda x, y = expr: x == y
             self.expressions.append(expr)
-    
+
     def __call__(self, *values):
         for expr in self.expressions:
             for value in values:
@@ -216,6 +223,7 @@ class Expression(object):
     Evaluate the expression with a transmogrifier context.
     
     """
+
     def __init__(self, expression, transmogrifier, name, options, **extras):
         self.expression = engine.TrustedEngine.compile(expression)
         self.transmogrifier = transmogrifier
@@ -229,12 +237,12 @@ class Expression(object):
     def __call__(self, item, **extras):
         extras.update(self.extras)
         result = self.expression(engine.TrustedEngine.getContext(
-            item = item,
-            transmogrifier = self.transmogrifier,
-            name = self.name,
-            options = self.options,
-            nothing = None,
-            modules = sys.modules,
+            item=item,
+            transmogrifier=self.transmogrifier,
+            name=self.name,
+            options=self.options,
+            nothing=None,
+            modules=sys.modules,
             **extras
         ))
         if self.logger.isEnabledFor(DEBUG):
@@ -242,11 +250,13 @@ class Expression(object):
             self.logger.debug('Expression returned: %s', formatted)
         return result
 
+
 class Condition(Expression):
     """A transmogrifier condition expression
     
     Test if a pipeline item matches the given TALES expression.
     
     """
+
     def __call__(self, item, **extras):
         return bool(super(Condition, self).__call__(item, **extras))

--- a/src/collective/transmogrifier/utils.py
+++ b/src/collective/transmogrifier/utils.py
@@ -260,3 +260,37 @@ class Condition(Expression):
 
     def __call__(self, item, **extras):
         return bool(super(Condition, self).__call__(item, **extras))
+
+
+def wrapped_tarball(export_context, context):
+    """
+    Return a tarball, created as an export context, for download
+
+    Usage exmaple:
+
+      transmogrifier(...)
+      for info in transmogrifier.get_info('export_context', short=True):
+	  # there should be exactly one:
+	  return wrapped_tarball(info['context'], self.context)
+    """
+    result = _export_result_dict(export_context)
+    RESPONSE = context.REQUEST.RESPONSE
+    RESPONSE.setHeader('Content-type', 'application/x-gzip')
+    RESPONSE.setHeader('Content-disposition',
+                       'attachment; filename=%s' % result['filename'])
+    return result['tarball']
+
+
+def _export_result_dict(context, steps=None, messages=None):
+    """
+    Return a dictionary, like returned by SetupTool._doRunExportSteps
+    (Products/GenericSetup/tool.py)
+
+    context -- an *export* context!
+
+    (helper for --> wrapped_tarball)
+    """
+    return {'steps': steps,
+            'messages': messages,
+            'tarball': context.getArchive(),
+            'filename': context.getArchiveFilename()}


### PR DESCRIPTION
This pull request includes the format changes of issue #7 (I like to rectify the format first before applying meaningful changes in a separate step) but mainly addresses #6, a way to accumulate information during processing. My use case is the download of a generated tarball; but there could be more. Thus I don't propose a special change for tarballs only; it is supposed to be helpful for different purposes.

Currently there is no way to get the export context (which was created by some section of a pipeline), e.g. to offer to download it; the Generic setup tool creates the context itself (and is supposed to have  `quintagroup.transmogrifer` use it somehow when exporting the site content, but this doesn't work for me). However, transmogrifier sections can create export contexts themselves, and we should be able to access them in a standard way. (Currently they are completely hidden from the calling code, and not even accessible via the transmogrifier object afterwards.)

The idea is to fill a list of information chunks; along with the information itself, there is a category (e.g. `export_context`) and the name of the `session` which added it. Thus, it is possible to easily get all information added by a certain session, or of a certain category. When producing a tarball for download, we could iterate over "all" information of the `export_context` type (there will be typically exactly one) and return a response which contains the tarball easily. (If the tarball has not been created, we could easily redirect to a page and display error messages instead.)

Other use cases could be detailed information about some in-site processing (e.g. encoding fixed for 753 of 29384 objects), or about imported objects.